### PR TITLE
Switch to v2 API, restore general functionality

### DIFF
--- a/html/home.html
+++ b/html/home.html
@@ -1,8 +1,8 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
   <head>
-    <link href='/css/global.css' rel='stylesheet' type='text/css'>
-    <link href='/css/home.css' rel='stylesheet' type='text/css'>
+    <link href="/css/global.css" rel="stylesheet" type="text/css" />
+    <link href="/css/home.css" rel="stylesheet" type="text/css" />
     <script src="/js/lib/moment.min.js"></script>
     <script src="/js/helper.js"></script>
     <script src="/js/home.js"></script>
@@ -11,9 +11,9 @@
     <!-- Info panel -->
     <div class="info">
       <div>
-        Welcome to Wanikani Companion! <br/><br/>
+        Welcome to Wanikani Companion! <br /><br />
         Please set your User API Key in the settings page.
-        <img src="/img/arrow.png" height="230px"/>
+        <img src="/img/arrow.png" height="230px" />
       </div>
     </div>
     <!-- Content -->
@@ -21,13 +21,13 @@
       <!-- Profile information -->
       <div id="profile">
         <div class="avatar">
-          <img id="gravatar" src="/img/wanikani/default-avatar.png"/>
+          <img id="gravatar" src="/img/wanikani/default-avatar.png" />
         </div>
         <div id="userInfo">
           <div>
             <h3 id="username"></h3>
-            <br/>of Sect. <span id="title"></span>
-            <br/><br/><h3> level <span id="level"></span></h3>
+            <br /><br />
+            <h3>level <span id="level"></span></h3>
           </div>
         </div>
       </div>
@@ -51,12 +51,8 @@
         </a>
         <!-- Next review -->
         <div id="nextReviews" href="/html/web-container.html">
-          <div>
-            No reviews left.
-          </div>
-          <div>
-            Next review <span id="reviewTime"></span>.
-          </div>
+          <div>No reviews left.</div>
+          <div>Next review <span id="reviewTime"></span>.</div>
         </div>
       </div>
       <!-- Dashboard link -->
@@ -68,23 +64,23 @@
       <!-- SRS level -->
       <div id="srs">
         <div id="apprentice">
-          <img src="/img/wanikani/srs-apprentice.png"/>
+          <img src="/img/wanikani/srs-apprentice.png" />
           <span id="srsNbApprentice"></span>
         </div>
         <div id="guru">
-          <img src="/img/wanikani/srs-guru.png"/>
+          <img src="/img/wanikani/srs-guru.png" />
           <span id="srsNbGuru"></span>
         </div>
         <div id="master">
-          <img src="/img/wanikani/srs-master.png"/>
+          <img src="/img/wanikani/srs-master.png" />
           <span id="srsNbMaster"></span>
         </div>
         <div id="enlighten">
-          <img src="/img/wanikani/srs-enlighten.png"/>
+          <img src="/img/wanikani/srs-enlighten.png" />
           <span id="srsNbEnlighten"></span>
         </div>
         <div id="burned">
-          <img src="/img/wanikani/srs-burned.png"/>
+          <img src="/img/wanikani/srs-burned.png" />
           <span id="srsNbBurned"></span>
         </div>
       </div>
@@ -95,5 +91,5 @@
         </div>
       </a>
     </div>
-    </body>
+  </body>
 </html>

--- a/html/settings.html
+++ b/html/settings.html
@@ -1,9 +1,10 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
   <head>
-    <link href='/css/global.css' rel='stylesheet' type='text/css'>
-    <link href='/css/settings.css' rel='stylesheet' type='text/css'>
+    <link href="/css/global.css" rel="stylesheet" type="text/css" />
+    <link href="/css/settings.css" rel="stylesheet" type="text/css" />
     <script src="/js/lib/moment.min.js"></script>
+    <script src="/js/lib/webtoolkit.md5.js"></script>
     <script src="/js/helper.js"></script>
     <script src="/js/settings.js"></script>
   </head>
@@ -11,7 +12,7 @@
     <!-- Info panel -->
     <div class="info">
       <div>
-        Saving data...<br/>
+        Saving data...<br />
         <div id="loader"></div>
       </div>
     </div>
@@ -26,42 +27,47 @@
 
       <div class="middle">
         <ul>
-          <li>User API key <span class="error"> // This key is not valid</span></li>
-          <li><input id="apiKey" type="text" size="30"/></li>
+          <li>
+            User API V2 key <span class="error"> // This key is not valid</span>
+          </li>
+          <li><input id="apiKey" type="text" size="30" /></li>
+          <li>Email Address (for Gravatar Image)</li>
+          <li><input id="emailAddress" type="email" /></li>
           <li class="spaced">Data refresh interval</li>
           <li>
             <select id="refreshInterval">
-              <option value="300000"> 5mn </option>
-              <option value="900000"> 15mn </option>
-              <option value="1800000"> 30mn </option>
-              <option value="3600000"> 1h </option>
-              <option value="7200000"> 2h </option>
+              <option value="300000">5mn</option>
+              <option value="900000">15mn</option>
+              <option value="1800000">30mn</option>
+              <option value="3600000">1h</option>
+              <option value="7200000">2h</option>
             </select>
           </li>
           <li class="spaced">Notifications lifetime</li>
           <li>
             <select id="notifLifetime">
-              <option value="0"> no notifications </option>
-              <option value="10000"> 10sec </option>
-              <option value="30000"> 30sec </option>
-              <option value="60000"> 1mn </option>
-              <option value="300000"> 5mn </option>
-              <option value="600000"> 10mn </option>
-              <option value="-1"> no limit </option>
+              <option value="0">no notifications</option>
+              <option value="10000">10sec</option>
+              <option value="30000">30sec</option>
+              <option value="60000">1mn</option>
+              <option value="300000">5mn</option>
+              <option value="600000">10mn</option>
+              <option value="-1">no limit</option>
             </select>
           </li>
-          <br>
           <li class="spaced">
-            <input id="notifSound" type="checkbox"> Enable notifications sound
+            <input id="notifSound" type="checkbox" /> Enable notifications sound
           </li>
           <li class="spaced">
-            <input id="inAppNav" type="checkbox"> Use in-app navigation
+            <input id="inAppNav" type="checkbox" /> Use in-app navigation
           </li>
           <li class="spaced">
-            <input id="expandInfoPanel" type="checkbox"> Auto-expand "item info" panel
+            <input id="expandInfoPanel" type="checkbox" /> Auto-expand "item
+            info" panel
           </li>
           <li class="spaced">
-            <input id="hide0Badge" type="checkbox"> Hide badge when no reviews or lessons
+            <input id="hide0Badge" type="checkbox" /> Hide badge when no reviews
+            or lessons
           </li>
         </ul>
       </div>
@@ -72,6 +78,5 @@
         </div>
       </a>
     </div>
-    
   </body>
 </html>

--- a/js/background.js
+++ b/js/background.js
@@ -1,16 +1,14 @@
-window.onload = function() {
-  
+window.onload = function () {
   var loopRequestId;
-
   // initialize the badge color
-  chrome.browserAction.setBadgeBackgroundColor({color:'#ff00aa'}); 
+  chrome.browserAction.setBadgeBackgroundColor({ color: "#ff00aa" });
 
   // check that there is a Chrome sync value
   chrome.storage.sync.get("wkUserData", function (obj) {
-    if (obj.wkUserData === undefined){
-      if (localStorage.wkUserData === undefined){
-          // if a local storage does not exist, initialize it
-          setWkUserData(new WkUserData());
+    if (obj.wkUserData === undefined) {
+      if (localStorage.wkUserData === undefined) {
+        // if a local storage does not exist, initialize it
+        setWkUserData(new WkUserData());
       }
     } else {
       // get the existing user data from Chrome sync
@@ -18,18 +16,23 @@ window.onload = function() {
     }
     loopRequestUserData();
   });
-  
+
   // update data every x milliseconds
-  function loopRequestUserData(){
+  function loopRequestUserData() {
     var wkUserData = JSON.parse(localStorage.wkUserData);
-    requestUserData(true, function(){
-      loopRequestId = window.setTimeout(loopRequestUserData, wkUserData.refreshInterval, true, true);
+    requestUserData(true, function () {
+      loopRequestId = window.setTimeout(
+        loopRequestUserData,
+        wkUserData.refreshInterval,
+        true,
+        true
+      );
     });
   }
 
   // when the update interval is changed, restart loopRequestUserData with the updated interval
-  chrome.storage.onChanged.addListener(function(changes, namespace) {
-    if ('wkUserData' in changes && loopRequestId !== undefined) {
+  chrome.storage.onChanged.addListener(function (changes, namespace) {
+    if ("wkUserData" in changes && loopRequestId !== undefined) {
       var oldValues = changes.wkUserData.oldValue;
       var newValues = changes.wkUserData.newValue;
       if (newValues.refreshInterval != oldValues.refreshInterval) {
@@ -41,19 +44,19 @@ window.onload = function() {
 
   // disable 'X-Frame-Options' header to allow inlining pages within an iframe
   chrome.webRequest.onHeadersReceived.addListener(
-      function(details) {
-          var headers = details.responseHeaders;
-          for (var i = 0; i < headers.length; ++i) { 
-            if (headers[i].name == 'X-Frame-Options') {
-                headers.splice(i, 1);
-                break;
-            }
-          }
-          return {responseHeaders: headers};
-      },
-      {
-          urls: [ '*://*/*' ]
-      },
-      ['blocking', 'responseHeaders']
+    function (details) {
+      var headers = details.responseHeaders;
+      for (var i = 0; i < headers.length; ++i) {
+        if (headers[i].name == "X-Frame-Options") {
+          headers.splice(i, 1);
+          break;
+        }
+      }
+      return { responseHeaders: headers };
+    },
+    {
+      urls: ["*://*/*"],
+    },
+    ["blocking", "responseHeaders"]
   );
-}
+};

--- a/js/helper.js
+++ b/js/helper.js
@@ -1,5 +1,5 @@
 // initialize the local object for user data
-function WkUserData(){
+function WkUserData() {
   this.userPublicKey = "";
   this.refreshInterval = 900000;
   this.notifLifetime = 10000;
@@ -9,9 +9,9 @@ function WkUserData(){
   this.notifSound = false;
 
   this.username = "Mysterious Unknown";
+  this.emailAddress = "";
   this.gravatar = "";
   this.level = "42";
-  this.title = "Legend";
   this.nbLessons = 0;
   this.nbReviews = 0;
   this.srsNbApprentice = 0;
@@ -19,40 +19,114 @@ function WkUserData(){
   this.srsNbMaster = 0;
   this.srsNbEnlighten = 0;
   this.srsNbBurned = 0;
+  this.assignmentsLastModified = null;
+  this.summaryLastModified = null;
 }
 
 // save the local user data
-function setWkUserData(wkUserData, callback){
+function setWkUserData(wkUserData, callback) {
   // save the data into the local storage
   localStorage.wkUserData = JSON.stringify(wkUserData);
   // ... and sync it with the current Chrome account
-  chrome.storage.sync.set({'wkUserData': wkUserData});
+  chrome.storage.sync.set({ wkUserData: wkUserData });
 
   if (callback) callback();
 }
 
 // get the local user data as an object
-function getWkUserData(){
+function getWkUserData() {
   return JSON.parse(localStorage.wkUserData);
 }
 
 // get the user data via the WaniKani API
 function getApiData(publicKey, type, callback) {
   var xhr = new XMLHttpRequest();
-  xhr.open("GET", "https://www.wanikani.com/api/user/" + publicKey + "/" + type, true);
-  xhr.onreadystatechange = function() {
-    if (xhr.readyState == 4) {
-      callback(JSON.parse(xhr.responseText));
-    }
+
+  const modifiedDate =
+    type === "user"
+      ? null
+      : type === "summary"
+      ? "summaryLastModified"
+      : "assignmentsLastModified";
+  xhr.open("GET", `https://api.wanikani.com/v2/${type}`, true);
+  xhr.setRequestHeader("Authorization", `Bearer ${publicKey}`);
+  xhr.setRequestHeader("Cache-Control", "no-cache");
+  if (modifiedDate && JSON.parse(localStorage.wkUserData)[modifiedDate]) {
+    xhr.setRequestHeader(
+      "If-Modified-Since",
+      moment(JSON.parse(localStorage.wkUserData)[modifiedDate]).format(
+        "ddd, DD MMM YYYY HH:mm:ss [GMT]"
+      )
+    );
   }
+  xhr.onreadystatechange = function () {
+    if (xhr.readyState == 4) {
+      const response = xhr.responseText ? JSON.parse(xhr.responseText) : {};
+      callback(response);
+    }
+  };
   xhr.send();
+}
+
+function fetchAssignmentsLoop(
+  publicKey,
+  callback,
+  assignments = [],
+  nextUrl = ""
+) {
+  getApiData(publicKey, `assignments?hidden=false${nextUrl}`, function (
+    responseData
+  ) {
+    if (!responseData.data) return null;
+    const nextAssignments = assignments.concat(responseData.data);
+    if (responseData.pages.next_url) {
+      const nextUrlId = responseData.data[responseData.data.length - 1].id;
+      fetchAssignmentsLoop(
+        publicKey,
+        callback,
+        nextAssignments,
+        `&page_after_id=${nextUrlId}`
+      );
+    } else {
+      const srsDistributionOfAssignments = {
+        apprentice: 0,
+        guru: 0,
+        master: 0,
+        enlighten: 0,
+        burned: 0,
+        assignmentsLastModified: responseData.data_updated_at,
+      };
+      nextAssignments.forEach(assignment => {
+        const srsStage = assignment.data.srs_stage;
+        if (srsStage > 0 && srsStage <= 4) {
+          srsDistributionOfAssignments.apprentice += 1;
+        } else if (srsStage > 4 && srsStage <= 6) {
+          srsDistributionOfAssignments.guru += 1;
+        } else if (srsStage == 7) {
+          srsDistributionOfAssignments.master += 1;
+        } else if (srsStage == 8) {
+          srsDistributionOfAssignments.enlighten += 1;
+        } else if (srsStage == 9) {
+          srsDistributionOfAssignments.burned += 1;
+        }
+      });
+      updateWkUserData(
+        srsDistributionOfAssignments,
+        "srs-distribution",
+        function () {
+          if (callback) callback();
+        }
+      );
+      // return srsDistributionOfAssignments;
+    }
+  });
 }
 
 // get a human readable value of the remaning time before the [reviewDate]
 function parseRemainingTime(reviewDate) {
-  if (reviewDate){
+  if (reviewDate) {
     var now = moment();
-    var review = moment(new Date(reviewDate*1000));
+    var review = moment(reviewDate);
     return review.from(now);
   }
   // [reviewDate] is null when the user hasn't done any lesson yet
@@ -60,26 +134,26 @@ function parseRemainingTime(reviewDate) {
 }
 
 // update the local user data from the JSON data returned from the WaniKani API
-function updateWkUserData(jsonUserData, type, callback){
-
+function updateWkUserData(jsonUserData, type, callback) {
   var wkUserData = JSON.parse(localStorage.wkUserData);
 
-  wkUserData.username = jsonUserData.user_information.username;
-  wkUserData.gravatar = jsonUserData.user_information.gravatar;
-  wkUserData.level = jsonUserData.user_information.level;
-  wkUserData.title = jsonUserData.user_information.title;
-
-  if (type == "study-queue") {
-    wkUserData.nbLessons = jsonUserData.requested_information.lessons_available;
-    wkUserData.nbReviews = jsonUserData.requested_information.reviews_available;
-    wkUserData.nextReview = parseRemainingTime(jsonUserData.requested_information.next_review_date);
-
-  } else if (type == "srs-distribution") {
-    wkUserData.srsNbApprentice = jsonUserData.requested_information.apprentice.total;
-    wkUserData.srsNbGuru = jsonUserData.requested_information.guru.total;
-    wkUserData.srsNbMaster = jsonUserData.requested_information.master.total;
-    wkUserData.srsNbEnlighten = jsonUserData.requested_information.enlighten.total;
-    wkUserData.srsNbBurned = jsonUserData.requested_information.burned.total;
+  if (type == "summary" && jsonUserData.data) {
+    wkUserData.nbLessons = jsonUserData.data.lessons[0].subject_ids.length;
+    const nextReviews = jsonUserData.data.reviews.find(
+      rev => rev.subject_ids.length > 0
+    );
+    wkUserData.nbReviews = nextReviews ? nextReviews.subject_ids.length : 0;
+    wkUserData.nextReview = parseRemainingTime(
+      jsonUserData.data.next_reviews_at
+    );
+    wkUserData.summaryLastModified = jsonUserData.data_updated_at;
+  } else if (type == "srs-distribution" && jsonUserData) {
+    wkUserData.srsNbApprentice = jsonUserData.apprentice;
+    wkUserData.srsNbGuru = jsonUserData.guru;
+    wkUserData.srsNbMaster = jsonUserData.master;
+    wkUserData.srsNbEnlighten = jsonUserData.enlighten;
+    wkUserData.srsNbBurned = jsonUserData.burned;
+    wkUserData.assignmentsLastModified = jsonUserData.assignmentsLastModified;
   }
 
   setWkUserData(wkUserData);
@@ -89,77 +163,94 @@ function updateWkUserData(jsonUserData, type, callback){
 
 // request the data to Wanikani API, display notifications and save local data
 function requestUserData(notify, callback) {
-
   var currentData = getWkUserData();
-
   // update data and display notifications
   if (currentData.userPublicKey != "") {
-
     // get lessons and reviews data
-    getApiData(currentData.userPublicKey, "study-queue", function(userData){
-
-      var nbReviews = userData.requested_information.reviews_available;
-      var nbLessons = userData.requested_information.lessons_available;
+    getApiData(currentData.userPublicKey, "summary", function (userData) {
+      const nextReviews = userData.data
+        ? userData.data.reviews.find(rev => rev.subject_ids.length > 0)
+        : null;
+      var nbLessons = userData.data
+        ? userData.data.lessons[0].subject_ids.length
+        : currentData.nbLessons;
+      var nbReviews = userData.data
+        ? nextReviews
+          ? nextReviews.subject_ids.length
+          : 0
+        : currentData.nbReviews;
 
       // display desktop notifications
-      if (notify === true && currentData.refreshInterval != 0){
-          var notified = false;
-          if (nbReviews > 0 && nbReviews != currentData.nbReviews) {
-            createNotification("You have " + nbReviews +" reviews available.", "https://www.wanikani.com/review", "reviews");
-            notified = true;
-          }
-          //if (nbLessons > 0 && nbLessons != currentData.nbLessons) {
-          if (nbLessons > 0 && nbLessons != currentData.nbLessons) {
-            createNotification("You have " + nbLessons +" lessons available.", "https://www.wanikani.com/lesson", "lessons");
-            notified = true;
-          }
-          // play notification sound
-          if (notified === true && currentData.notifSound === true){
-            var sound = new Audio('/snd/notification.mp3');
-            sound.play();
-          }
+      if (notify === true && currentData.refreshInterval != 0) {
+        var notified = false;
+        if (nbReviews > 0 && nbReviews != currentData.nbReviews) {
+          createNotification(
+            "You have " + nbReviews + " reviews available.",
+            "https://www.wanikani.com/review",
+            "reviews"
+          );
+          notified = true;
+        }
+        //if (nbLessons > 0 && nbLessons != currentData.nbLessons) {
+        if (nbLessons > 0 && nbLessons != currentData.nbLessons) {
+          createNotification(
+            "You have " + nbLessons + " lessons available.",
+            "https://www.wanikani.com/lesson",
+            "lessons"
+          );
+          notified = true;
+        }
+        // play notification sound
+        if (notified === true && currentData.notifSound === true) {
+          var sound = new Audio("/snd/notification.mp3");
+          sound.play();
+        }
       }
 
       // update badge text and title
-      var total = nbReviews+nbLessons;
+      var total = nbReviews + nbLessons;
       if (total == 0 && currentData.hide0Badge) {
-        chrome.browserAction.setBadgeText({text:""});
+        chrome.browserAction.setBadgeText({ text: "" });
       } else {
-        chrome.browserAction.setBadgeText({text:total.toString()});
+        chrome.browserAction.setBadgeText({ text: total.toString() });
       }
-      chrome.browserAction.setTitle({title: "WaniKani Companion\n" + "Lesson(s): " + nbLessons + "\n" + "Review(s): " + nbReviews});
-      
-      // save study data
-      updateWkUserData(userData, "study-queue", function(){
-        // get the srs distribution data
-        getApiData(currentData.userPublicKey, "srs-distribution" ,function(userData){
-          // save srs distribution data
-          updateWkUserData(userData, "srs-distribution", function(){ if (callback) callback(); });
-        });
+      chrome.browserAction.setTitle({
+        title:
+          "WaniKani Companion\n" +
+          "Lesson(s): " +
+          nbLessons +
+          "\n" +
+          "Review(s): " +
+          nbReviews,
       });
 
+      // save study data
+      updateWkUserData(userData, "summary", function () {
+        fetchAssignmentsLoop(currentData.userPublicKey, callback);
+      });
     });
   }
 }
 
 // create a HTML notification
-function createNotification(body, url, tag){
-
-  var notification = new Notification('WaniKani Companion', {
-    icon: '/img/wanikani/icon.png',
+function createNotification(body, url, tag) {
+  var notification = new Notification("WaniKani Companion", {
+    icon: "/img/wanikani/icon.png",
     body: body,
-    tag: tag
+    tag: tag,
   });
 
-  notification.onclick = function() {
+  notification.onclick = function () {
     window.open(url);
-  }
+  };
 
   // vanish the notifications after [notifLifetime] ms
   // if [notifLifetime] == -1, the notification stay until the user close it
   if (getWkUserData().notifLifetime != -1) {
-    notification.onshow = function() {
-      window.setTimeout(function() { notification.close() }, getWkUserData().notifLifetime);
-    }
+    notification.onshow = function () {
+      window.setTimeout(function () {
+        notification.close();
+      }, getWkUserData().notifLifetime);
+    };
   }
 }

--- a/js/home.js
+++ b/js/home.js
@@ -1,14 +1,16 @@
-window.onload = function() {
-
+window.onload = function () {
   var wkUserData = JSON.parse(localStorage.wkUserData);
   fullfillUserData();
 
   // display info message if the user is coming for the first time
-  if (wkUserData.userPublicKey === undefined || wkUserData.userPublicKey == ""){
-    document.querySelector(".info").style.display = 'inline';
+  if (
+    wkUserData.userPublicKey === undefined ||
+    wkUserData.userPublicKey == ""
+  ) {
+    document.querySelector(".info").style.display = "inline";
   } else {
-     // reload user data
-    requestUserData(false, function() {
+    // reload user data
+    requestUserData(false, function () {
       wkUserData = JSON.parse(localStorage.wkUserData);
       fullfillUserData();
     });
@@ -16,66 +18,71 @@ window.onload = function() {
 
   // display Gravatar image (if exist)
   var xhr = new XMLHttpRequest();
-  xhr.open("GET", 'http://www.gravatar.com/avatar/' + wkUserData.gravatar + '?d=404', true);
-  xhr.onreadystatechange = function() {
+  xhr.open(
+    "GET",
+    "http://www.gravatar.com/avatar/" + wkUserData.gravatar + "?d=404",
+    true
+  );
+  xhr.onreadystatechange = function () {
     if (xhr.readyState == 4) {
       if (xhr.status == 200) {
-        document.getElementById('gravatar').src = 'http://www.gravatar.com/avatar/' + wkUserData.gravatar;
+        document.getElementById("gravatar").src =
+          "http://www.gravatar.com/avatar/" + wkUserData.gravatar;
       }
     }
-  }
+  };
   xhr.send();
 
   // when the user click on a link, it redirect the url to the web-container page or a new Chrome tab (depends on user settings)
   var inApp = wkUserData.inAppNavigation;
-  document.getElementById('toLessons').onclick = function() {
-    var url = "https://www.wanikani.com/lesson/session"
-    if (inApp){
+  document.getElementById("toLessons").onclick = function () {
+    var url = "https://www.wanikani.com/lesson/session";
+    if (inApp) {
       localStorage.toLink = url;
     } else {
       chrome.tabs.create({ url: url });
     }
-  }
-  document.getElementById('toReviews').onclick = function() {
+  };
+  document.getElementById("toReviews").onclick = function () {
     var url = "https://www.wanikani.com/review/session";
-    if (inApp){
-     localStorage.toLink = url;
+    if (inApp) {
+      localStorage.toLink = url;
     } else {
-     chrome.tabs.create({ url: url });
+      chrome.tabs.create({ url: url });
     }
-  }
-  document.getElementById('toDashboard').onclick = function() {
-     var url = "https://www.wanikani.com/login";
-     if (inApp){
-       localStorage.toLink = url;
-     } else {
-       chrome.tabs.create({ url: url });
-     }
-  }
+  };
+  document.getElementById("toDashboard").onclick = function () {
+    var url = "https://www.wanikani.com/login";
+    if (inApp) {
+      localStorage.toLink = url;
+    } else {
+      chrome.tabs.create({ url: url });
+    }
+  };
 
   // fullfill user data
-  function fullfillUserData(){
+  function fullfillUserData() {
+    document.getElementById("username").innerHTML = wkUserData.username;
+    document.getElementById("level").innerHTML = wkUserData.level;
+    document.getElementById("nbLessons").innerHTML = wkUserData.nbLessons;
+    document.getElementById("nbReviews").innerHTML = wkUserData.nbReviews;
+    document.getElementById("reviewTime").innerHTML = wkUserData.nextReview;
+    document.getElementById("srsNbApprentice").innerHTML =
+      wkUserData.srsNbApprentice;
+    document.getElementById("srsNbGuru").innerHTML = wkUserData.srsNbGuru;
+    document.getElementById("srsNbMaster").innerHTML = wkUserData.srsNbMaster;
+    document.getElementById("srsNbEnlighten").innerHTML =
+      wkUserData.srsNbEnlighten;
+    document.getElementById("srsNbBurned").innerHTML = wkUserData.srsNbBurned;
 
-     document.getElementById('username').innerHTML = wkUserData.username;
-     document.getElementById('level').innerHTML = wkUserData.level;
-     document.getElementById('title').innerHTML = wkUserData.title;
-     document.getElementById('nbLessons').innerHTML = wkUserData.nbLessons;
-     document.getElementById('nbReviews').innerHTML = wkUserData.nbReviews;
-     document.getElementById('reviewTime').innerHTML = wkUserData.nextReview;
-     document.getElementById('srsNbApprentice').innerHTML = wkUserData.srsNbApprentice;
-     document.getElementById('srsNbGuru').innerHTML = wkUserData.srsNbGuru;
-     document.getElementById('srsNbMaster').innerHTML = wkUserData.srsNbMaster;
-     document.getElementById('srsNbEnlighten').innerHTML = wkUserData.srsNbEnlighten;
-     document.getElementById('srsNbBurned').innerHTML = wkUserData.srsNbBurned;
-
-     if (wkUserData.nbReviews > 0 || !wkUserData.nextReview){
-         // the user has reviews, or does not have next reviews
-         document.querySelector("#reviews").style.display = 'block';
-         document.querySelector("#nextReviews").style.display = 'none';
-     } else {
-         // the user does not have available reviews, display when will be the next one
-         document.querySelector("#reviews").style.display = 'none';
-         document.querySelector("#nextReviews").style.display = 'block';
-     }
+    if (wkUserData.nbReviews > 0 || !wkUserData.nextReview) {
+      // the user has reviews, or does not have next reviews
+      document.querySelector("#reviews").style.display = "block";
+      document.querySelector("#nextReviews").style.display = "none";
+    } else {
+      // the user does not have available reviews, display when will be the next one
+      document.querySelector("#reviews").style.display = "none";
+      document.querySelector("#nextReviews").style.display = "block";
+    }
   }
-}
+};

--- a/js/lib/webtoolkit.md5.js
+++ b/js/lib/webtoolkit.md5.js
@@ -1,0 +1,590 @@
+/**
+
+*
+
+*  MD5 (Message-Digest Algorithm)
+
+*  http://www.webtoolkit.info/
+
+*
+
+**/
+
+
+
+
+var MD5 = function (string) {
+
+
+
+
+    function RotateLeft(lValue, iShiftBits) {
+
+
+        return (lValue<<iShiftBits) | (lValue>>>(32-iShiftBits));
+
+
+    }
+
+
+
+
+    function AddUnsigned(lX,lY) {
+
+
+        var lX4,lY4,lX8,lY8,lResult;
+
+
+        lX8 = (lX & 0x80000000);
+
+
+        lY8 = (lY & 0x80000000);
+
+
+        lX4 = (lX & 0x40000000);
+
+
+        lY4 = (lY & 0x40000000);
+
+
+        lResult = (lX & 0x3FFFFFFF)+(lY & 0x3FFFFFFF);
+
+
+        if (lX4 & lY4) {
+
+
+            return (lResult ^ 0x80000000 ^ lX8 ^ lY8);
+
+
+        }
+
+
+        if (lX4 | lY4) {
+
+
+            if (lResult & 0x40000000) {
+
+
+                return (lResult ^ 0xC0000000 ^ lX8 ^ lY8);
+
+
+            } else {
+
+
+                return (lResult ^ 0x40000000 ^ lX8 ^ lY8);
+
+
+            }
+
+
+        } else {
+
+
+            return (lResult ^ lX8 ^ lY8);
+
+
+        }
+
+
+     }
+
+
+
+
+     function F(x,y,z) { return (x & y) | ((~x) & z); }
+
+
+     function G(x,y,z) { return (x & z) | (y & (~z)); }
+
+
+     function H(x,y,z) { return (x ^ y ^ z); }
+
+
+    function I(x,y,z) { return (y ^ (x | (~z))); }
+
+
+
+
+    function FF(a,b,c,d,x,s,ac) {
+
+
+        a = AddUnsigned(a, AddUnsigned(AddUnsigned(F(b, c, d), x), ac));
+
+
+        return AddUnsigned(RotateLeft(a, s), b);
+
+
+    };
+
+
+
+
+    function GG(a,b,c,d,x,s,ac) {
+
+
+        a = AddUnsigned(a, AddUnsigned(AddUnsigned(G(b, c, d), x), ac));
+
+
+        return AddUnsigned(RotateLeft(a, s), b);
+
+
+    };
+
+
+
+
+    function HH(a,b,c,d,x,s,ac) {
+
+
+        a = AddUnsigned(a, AddUnsigned(AddUnsigned(H(b, c, d), x), ac));
+
+
+        return AddUnsigned(RotateLeft(a, s), b);
+
+
+    };
+
+
+
+
+    function II(a,b,c,d,x,s,ac) {
+
+
+        a = AddUnsigned(a, AddUnsigned(AddUnsigned(I(b, c, d), x), ac));
+
+
+        return AddUnsigned(RotateLeft(a, s), b);
+
+
+    };
+
+
+
+
+    function ConvertToWordArray(string) {
+
+
+        var lWordCount;
+
+
+        var lMessageLength = string.length;
+
+
+        var lNumberOfWords_temp1=lMessageLength + 8;
+
+
+        var lNumberOfWords_temp2=(lNumberOfWords_temp1-(lNumberOfWords_temp1 % 64))/64;
+
+
+        var lNumberOfWords = (lNumberOfWords_temp2+1)*16;
+
+
+        var lWordArray=Array(lNumberOfWords-1);
+
+
+        var lBytePosition = 0;
+
+
+        var lByteCount = 0;
+
+
+        while ( lByteCount < lMessageLength ) {
+
+
+            lWordCount = (lByteCount-(lByteCount % 4))/4;
+
+
+            lBytePosition = (lByteCount % 4)*8;
+
+
+            lWordArray[lWordCount] = (lWordArray[lWordCount] | (string.charCodeAt(lByteCount)<<lBytePosition));
+
+
+            lByteCount++;
+
+
+        }
+
+
+        lWordCount = (lByteCount-(lByteCount % 4))/4;
+
+
+        lBytePosition = (lByteCount % 4)*8;
+
+
+        lWordArray[lWordCount] = lWordArray[lWordCount] | (0x80<<lBytePosition);
+
+
+        lWordArray[lNumberOfWords-2] = lMessageLength<<3;
+
+
+        lWordArray[lNumberOfWords-1] = lMessageLength>>>29;
+
+
+        return lWordArray;
+
+
+    };
+
+
+
+
+    function WordToHex(lValue) {
+
+
+        var WordToHexValue="",WordToHexValue_temp="",lByte,lCount;
+
+
+        for (lCount = 0;lCount<=3;lCount++) {
+
+
+            lByte = (lValue>>>(lCount*8)) & 255;
+
+
+            WordToHexValue_temp = "0" + lByte.toString(16);
+
+
+            WordToHexValue = WordToHexValue + WordToHexValue_temp.substr(WordToHexValue_temp.length-2,2);
+
+
+        }
+
+
+        return WordToHexValue;
+
+
+    };
+
+
+
+
+    function Utf8Encode(string) {
+
+
+        string = string.replace(/\r\n/g,"\n");
+
+
+        var utftext = "";
+
+
+
+
+        for (var n = 0; n < string.length; n++) {
+
+
+
+
+            var c = string.charCodeAt(n);
+
+
+
+
+            if (c < 128) {
+
+
+                utftext += String.fromCharCode(c);
+
+
+            }
+
+
+            else if((c > 127) && (c < 2048)) {
+
+
+                utftext += String.fromCharCode((c >> 6) | 192);
+
+
+                utftext += String.fromCharCode((c & 63) | 128);
+
+
+            }
+
+
+            else {
+
+
+                utftext += String.fromCharCode((c >> 12) | 224);
+
+
+                utftext += String.fromCharCode(((c >> 6) & 63) | 128);
+
+
+                utftext += String.fromCharCode((c & 63) | 128);
+
+
+            }
+
+
+
+
+        }
+
+
+
+
+        return utftext;
+
+
+    };
+
+
+
+
+    var x=Array();
+
+
+    var k,AA,BB,CC,DD,a,b,c,d;
+
+
+    var S11=7, S12=12, S13=17, S14=22;
+
+
+    var S21=5, S22=9 , S23=14, S24=20;
+
+
+    var S31=4, S32=11, S33=16, S34=23;
+
+
+    var S41=6, S42=10, S43=15, S44=21;
+
+
+
+
+    string = Utf8Encode(string);
+
+
+
+
+    x = ConvertToWordArray(string);
+
+
+
+
+    a = 0x67452301; b = 0xEFCDAB89; c = 0x98BADCFE; d = 0x10325476;
+
+
+
+
+    for (k=0;k<x.length;k+=16) {
+
+
+        AA=a; BB=b; CC=c; DD=d;
+
+
+        a=FF(a,b,c,d,x[k+0], S11,0xD76AA478);
+
+
+        d=FF(d,a,b,c,x[k+1], S12,0xE8C7B756);
+
+
+        c=FF(c,d,a,b,x[k+2], S13,0x242070DB);
+
+
+        b=FF(b,c,d,a,x[k+3], S14,0xC1BDCEEE);
+
+
+        a=FF(a,b,c,d,x[k+4], S11,0xF57C0FAF);
+
+
+        d=FF(d,a,b,c,x[k+5], S12,0x4787C62A);
+
+
+        c=FF(c,d,a,b,x[k+6], S13,0xA8304613);
+
+
+        b=FF(b,c,d,a,x[k+7], S14,0xFD469501);
+
+
+        a=FF(a,b,c,d,x[k+8], S11,0x698098D8);
+
+
+        d=FF(d,a,b,c,x[k+9], S12,0x8B44F7AF);
+
+
+        c=FF(c,d,a,b,x[k+10],S13,0xFFFF5BB1);
+
+
+        b=FF(b,c,d,a,x[k+11],S14,0x895CD7BE);
+
+
+        a=FF(a,b,c,d,x[k+12],S11,0x6B901122);
+
+
+        d=FF(d,a,b,c,x[k+13],S12,0xFD987193);
+
+
+        c=FF(c,d,a,b,x[k+14],S13,0xA679438E);
+
+
+        b=FF(b,c,d,a,x[k+15],S14,0x49B40821);
+
+
+        a=GG(a,b,c,d,x[k+1], S21,0xF61E2562);
+
+
+        d=GG(d,a,b,c,x[k+6], S22,0xC040B340);
+
+
+        c=GG(c,d,a,b,x[k+11],S23,0x265E5A51);
+
+
+        b=GG(b,c,d,a,x[k+0], S24,0xE9B6C7AA);
+
+
+        a=GG(a,b,c,d,x[k+5], S21,0xD62F105D);
+
+
+        d=GG(d,a,b,c,x[k+10],S22,0x2441453);
+
+
+        c=GG(c,d,a,b,x[k+15],S23,0xD8A1E681);
+
+
+        b=GG(b,c,d,a,x[k+4], S24,0xE7D3FBC8);
+
+
+        a=GG(a,b,c,d,x[k+9], S21,0x21E1CDE6);
+
+
+        d=GG(d,a,b,c,x[k+14],S22,0xC33707D6);
+
+
+        c=GG(c,d,a,b,x[k+3], S23,0xF4D50D87);
+
+
+        b=GG(b,c,d,a,x[k+8], S24,0x455A14ED);
+
+
+        a=GG(a,b,c,d,x[k+13],S21,0xA9E3E905);
+
+
+        d=GG(d,a,b,c,x[k+2], S22,0xFCEFA3F8);
+
+
+        c=GG(c,d,a,b,x[k+7], S23,0x676F02D9);
+
+
+        b=GG(b,c,d,a,x[k+12],S24,0x8D2A4C8A);
+
+
+        a=HH(a,b,c,d,x[k+5], S31,0xFFFA3942);
+
+
+        d=HH(d,a,b,c,x[k+8], S32,0x8771F681);
+
+
+        c=HH(c,d,a,b,x[k+11],S33,0x6D9D6122);
+
+
+        b=HH(b,c,d,a,x[k+14],S34,0xFDE5380C);
+
+
+        a=HH(a,b,c,d,x[k+1], S31,0xA4BEEA44);
+
+
+        d=HH(d,a,b,c,x[k+4], S32,0x4BDECFA9);
+
+
+        c=HH(c,d,a,b,x[k+7], S33,0xF6BB4B60);
+
+
+        b=HH(b,c,d,a,x[k+10],S34,0xBEBFBC70);
+
+
+        a=HH(a,b,c,d,x[k+13],S31,0x289B7EC6);
+
+
+        d=HH(d,a,b,c,x[k+0], S32,0xEAA127FA);
+
+
+        c=HH(c,d,a,b,x[k+3], S33,0xD4EF3085);
+
+
+        b=HH(b,c,d,a,x[k+6], S34,0x4881D05);
+
+
+        a=HH(a,b,c,d,x[k+9], S31,0xD9D4D039);
+
+
+        d=HH(d,a,b,c,x[k+12],S32,0xE6DB99E5);
+
+
+        c=HH(c,d,a,b,x[k+15],S33,0x1FA27CF8);
+
+
+        b=HH(b,c,d,a,x[k+2], S34,0xC4AC5665);
+
+
+        a=II(a,b,c,d,x[k+0], S41,0xF4292244);
+
+
+        d=II(d,a,b,c,x[k+7], S42,0x432AFF97);
+
+
+        c=II(c,d,a,b,x[k+14],S43,0xAB9423A7);
+
+
+        b=II(b,c,d,a,x[k+5], S44,0xFC93A039);
+
+
+        a=II(a,b,c,d,x[k+12],S41,0x655B59C3);
+
+
+        d=II(d,a,b,c,x[k+3], S42,0x8F0CCC92);
+
+
+        c=II(c,d,a,b,x[k+10],S43,0xFFEFF47D);
+
+
+        b=II(b,c,d,a,x[k+1], S44,0x85845DD1);
+
+
+        a=II(a,b,c,d,x[k+8], S41,0x6FA87E4F);
+
+
+        d=II(d,a,b,c,x[k+15],S42,0xFE2CE6E0);
+
+
+        c=II(c,d,a,b,x[k+6], S43,0xA3014314);
+
+
+        b=II(b,c,d,a,x[k+13],S44,0x4E0811A1);
+
+
+        a=II(a,b,c,d,x[k+4], S41,0xF7537E82);
+
+
+        d=II(d,a,b,c,x[k+11],S42,0xBD3AF235);
+
+
+        c=II(c,d,a,b,x[k+2], S43,0x2AD7D2BB);
+
+
+        b=II(b,c,d,a,x[k+9], S44,0xEB86D391);
+
+
+        a=AddUnsigned(a,AA);
+
+
+        b=AddUnsigned(b,BB);
+
+
+        c=AddUnsigned(c,CC);
+
+
+        d=AddUnsigned(d,DD);
+
+
+    }
+
+
+
+
+    var temp = WordToHex(a)+WordToHex(b)+WordToHex(c)+WordToHex(d);
+
+
+
+
+    return temp.toLowerCase();
+
+}

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,65 +1,95 @@
-window.onload = function() {
-
+window.onload = function () {
   var wkUserData = getWkUserData();
 
   // display current settings
-  document.getElementById('apiKey').value = wkUserData.userPublicKey;
-  document.getElementById('refreshInterval').value = wkUserData.refreshInterval;
-  document.getElementById('notifLifetime').value = wkUserData.notifLifetime;
-  document.getElementById('notifSound').checked = wkUserData.notifSound == true ? true : false;
-  document.getElementById('inAppNav').checked = wkUserData.inAppNavigation == true ? true : false;
-  document.getElementById('expandInfoPanel').checked = wkUserData.expandInfoPanel == true ? true : false;
-  document.getElementById('hide0Badge').checked = wkUserData.hide0Badge == true ? true : false;
+  document.getElementById("apiKey").value = wkUserData.userPublicKey;
+  document.getElementById("emailAddress").value = wkUserData.emailAddress;
+  document.getElementById("refreshInterval").value = wkUserData.refreshInterval;
+  document.getElementById("notifLifetime").value = wkUserData.notifLifetime;
+  document.getElementById("notifSound").checked =
+    wkUserData.notifSound == true ? true : false;
+  document.getElementById("inAppNav").checked =
+    wkUserData.inAppNavigation == true ? true : false;
+  document.getElementById("expandInfoPanel").checked =
+    wkUserData.expandInfoPanel == true ? true : false;
+  document.getElementById("hide0Badge").checked =
+    wkUserData.hide0Badge == true ? true : false;
 
   // action when settings are saved
-  document.getElementById('save').onclick = function() {
+  document.getElementById("save").onclick = function () {
+    document.querySelector(".error").style.display = "none";
+    document.querySelector(".info").style.display = "inline";
 
-    document.querySelector(".error").style.display = 'none';
-    document.querySelector(".info").style.display = 'inline';
-
-    var key = document.getElementById('apiKey').value;
+    var key = document.getElementById("apiKey").value;
 
     // the key is empty or didn't change: do not save
     if (key == "" || key == wkUserData.userPublicKey) {
+      wkUserData.refreshInterval = document.getElementById(
+        "refreshInterval"
+      ).value;
+      wkUserData.emailAddress = document.getElementById("emailAddress").value;
+      wkUserData.gravatar = MD5(document.getElementById("emailAddress").value);
+      wkUserData.notifLifetime = document.getElementById("notifLifetime").value;
+      wkUserData.notifSound = document.getElementById("notifSound").checked
+        ? true
+        : false;
+      wkUserData.inAppNavigation = document.getElementById("inAppNav").checked
+        ? true
+        : false;
+      wkUserData.expandInfoPanel = document.getElementById("expandInfoPanel")
+        .checked
+        ? true
+        : false;
+      wkUserData.hide0Badge = document.getElementById("hide0Badge").checked
+        ? true
+        : false;
 
-      wkUserData.refreshInterval = document.getElementById('refreshInterval').value;
-      wkUserData.notifLifetime = document.getElementById('notifLifetime').value;
-      wkUserData.notifSound = (document.getElementById('notifSound').checked) ? true : false;
-      wkUserData.inAppNavigation = (document.getElementById('inAppNav').checked) ? true : false;
-      wkUserData.expandInfoPanel = (document.getElementById('expandInfoPanel').checked) ? true : false;
-      wkUserData.hide0Badge = (document.getElementById('hide0Badge').checked) ? true : false;
-
-      setWkUserData(wkUserData, function() {
+      setWkUserData(wkUserData, function () {
         window.location.replace("/html/home.html");
       });
-    
-    // a new key has been entered: save
-    } else if (key != wkUserData.userPublicKey){
-        
-      getApiData(key, "user-information", function(obj){ 
 
+      // a new key has been entered: save
+    } else if (key != wkUserData.userPublicKey) {
+      getApiData(key, "user", function (obj) {
         // the key is not valid
-        if (obj.user_information === undefined){
-          document.querySelector(".error").style.display = 'inline';
-          document.querySelector(".info").style.display = 'none';
+        if (obj.data === undefined) {
+          document.querySelector(".error").style.display = "inline";
+          document.querySelector(".info").style.display = "none";
 
-        // the key is valid
-        } else { 
-          wkUserData.userPublicKey = document.getElementById('apiKey').value;
-          wkUserData.refreshInterval = document.getElementById('refreshInterval').value;
-          wkUserData.notifLifetime = document.getElementById('notifLifetime').value;
-          wkUserData.notifSound = (document.getElementById('notifSound').checked) ? true : false;
-          wkUserData.inAppNavigation = (document.getElementById('inAppNav').checked) ? true : false;
-          wkUserData.expandInfoPanel = (document.getElementById('expandInfoPanel').checked) ? true : false;
-          wkUserData.hide0Badge = (document.getElementById('hide0Badge').checked) ? true : false;
+          // the key is valid
+        } else {
+          wkUserData.userPublicKey = document.getElementById("apiKey").value;
+          wkUserData.username = obj.data.username;
+          wkUserData.level = obj.data.level;
+          wkUserData.refreshInterval = document.getElementById(
+            "refreshInterval"
+          ).value;
+          wkUserData.notifLifetime = document.getElementById(
+            "notifLifetime"
+          ).value;
+          wkUserData.notifSound = document.getElementById("notifSound").checked
+            ? true
+            : false;
+          wkUserData.inAppNavigation = document.getElementById("inAppNav")
+            .checked
+            ? true
+            : false;
+          wkUserData.expandInfoPanel = document.getElementById(
+            "expandInfoPanel"
+          ).checked
+            ? true
+            : false;
+          wkUserData.hide0Badge = document.getElementById("hide0Badge").checked
+            ? true
+            : false;
 
-          setWkUserData(wkUserData, function() {
-            requestUserData(false, function(){
+          setWkUserData(wkUserData, function () {
+            requestUserData(false, function () {
               window.location.replace("/html/home.html");
             });
           });
         }
       });
     }
-  }
-}
+  };
+};

--- a/manifest.json
+++ b/manifest.json
@@ -21,9 +21,7 @@
   "content_scripts": [
     {
       "matches": ["*://www.wanikani.com/*"],
-      "js": [
-        "/js/web-content.js"
-      ],
+      "js": ["/js/web-content.js"],
       "run_at": "document_start",
       "all_frames": true
     }
@@ -31,6 +29,7 @@
   "background": {
     "scripts": [
       "/js/lib/moment.min.js",
+      "/js/lib/webtoolkit.md5.js",
       "/js/helper.js",
       "/js/background.js"
     ]


### PR DESCRIPTION
## What?
I've updated the extension to use the Wanikani V2 API. This includes adding user input for an email address to retrieve Gravatar. 
## Why?
With the Wanikani v1 API being deprecated, the extension no longer functions. This fix restores almost all functionality.
## How?
This includes using the assignments, user and summary endpoints as appropriate, structuring response data to use existing methods as much as possible. Data last modified dates are stored in the userdata and sent with requests to use Wanikani's conditional requests. Email addresses are hashed to MD5 and stored in the userdata gravatar field. Sects are no longer supported in the API, and have been removed.
## Testing?
I've not done any formal testing, but have tried to keep functionality much the same as original functionality.