### PR TITLE
Add option to force a wait after a wrong answer

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -1,6 +1,6 @@
 @import url(http://fonts.googleapis.com/css?family=Alegreya+Sans+SC);
 body {
-  height: 460px;
+  height: 480px;
   width: 350px;
   margin: 0;
   color: #ffffff;

--- a/html/settings.html
+++ b/html/settings.html
@@ -69,6 +69,9 @@
             <input id="hide0Badge" type="checkbox" /> Hide badge when no reviews
             or lessons
           </li>
+          <li class="spaced">
+            <input id="blockOnIncorrect" type="checkbox" /> 3s block when incorrect
+          </li>
         </ul>
       </div>
 

--- a/js/helper.js
+++ b/js/helper.js
@@ -7,6 +7,7 @@ function WkUserData() {
   this.expandInfoPanel = true;
   this.hide0Badge = false;
   this.notifSound = false;
+  this.blockOnIncorrect = false;
 
   this.username = "Mysterious Unknown";
   this.emailAddress = "";

--- a/js/settings.js
+++ b/js/settings.js
@@ -14,6 +14,9 @@ window.onload = function () {
     wkUserData.expandInfoPanel == true ? true : false;
   document.getElementById("hide0Badge").checked =
     wkUserData.hide0Badge == true ? true : false;
+  document.getElementById("blockOnIncorrect").checked =
+    wkUserData.blockOnIncorrect == true ? true : false;
+
 
   // action when settings are saved
   document.getElementById("save").onclick = function () {
@@ -41,6 +44,9 @@ window.onload = function () {
         ? true
         : false;
       wkUserData.hide0Badge = document.getElementById("hide0Badge").checked
+        ? true
+        : false;
+      wkUserData.blockOnIncorrect = document.getElementById("blockOnIncorrect").checked
         ? true
         : false;
 
@@ -82,6 +88,9 @@ window.onload = function () {
             ? true
             : false;
           wkUserData.hide0Badge = document.getElementById("hide0Badge").checked
+            ? true
+            : false;
+          wkUserData.blockOnIncorrect = document.getElementById("blockOnIncorrect").checked
             ? true
             : false;
 

--- a/js/web-content.js
+++ b/js/web-content.js
@@ -1,15 +1,28 @@
-window.onload = function() {
+
+blockOnIncorrect = false;
+
+document.addEventListener("keydown", event => {
+  if (event.key === "Enter") {
+
+    //block if block is set
+    if (blockOnIncorrect) {
+      event.stopImmediatePropagation();
+    }
+  }
+});
+
+window.onload = function () {
 
   chrome.storage.sync.get("wkUserData", function (obj) {
     // review & lessons quiz: auto-expand the "item info" panel
-    if (obj.wkUserData.expandInfoPanel === true){
+    if (obj.wkUserData.expandInfoPanel === true) {
       if (document.getElementById('reviews') != null || document.getElementById('lessons') != null) {
-        var observer = new WebKitMutationObserver(function(mutations) {
-          mutations.forEach(function(mutation) {
+        var observer = new WebKitMutationObserver(function (mutations) {
+          mutations.forEach(function (mutation) {
             if (mutation.target.type === 'fieldset') {
               // wait and check that the panel is not already expanded before expanding it
-              setTimeout(function(){
-                if (document.getElementById('option-item-info').className != 'active'){
+              setTimeout(function () {
+                if (document.getElementById('option-item-info').className != 'active') {
                   document.getElementById('option-item-info').click();
                 }
               }, 200)
@@ -18,10 +31,38 @@ window.onload = function() {
           });
         });
         observer.observe(
-          document.getElementById('answer-form'), 
+          document.getElementById('answer-form'),
           {
-              attributes: true, 
-              subtree: true
+            attributes: true,
+            subtree: true
+          }
+        );
+      }
+    }
+
+    // block progress for 3 seconds on incorrect answer
+    if (obj.wkUserData.blockOnIncorrect === true) {
+      if (document.getElementById('reviews') != null || document.getElementById('lessons') != null) {
+
+        var observer = new WebKitMutationObserver(function (mutations) {
+          mutations.forEach(function (mutation) {
+            if (mutation.target.type === 'fieldset') {
+              // check the answer was incorrect
+              if (document.getElementsByClassName('incorrect').length > 0) {
+                blockOnIncorrect = true;
+                setTimeout(function () {
+                  // unset the block after 3 seconds
+                  blockOnIncorrect = false;
+                }, 3000)
+              }
+            }
+          });
+        });
+        observer.observe(
+          document.getElementById('answer-form'),
+          {
+            attributes: true,
+            subtree: true
           }
         );
       }
@@ -31,6 +72,6 @@ window.onload = function() {
   // hide the alert messages (ex: if the user is already logged)
   var isError = document.getElementsByClassName('alert alert-error fade in');
   if (isError.length == 1) {
-    isError[0].style.display='none';
+    isError[0].style.display = 'none';
   }
 }


### PR DESCRIPTION
This is something I personally needed to help me.
I got into such a habit of pressing enter twice after putting my answer in, that when I was wrong, it means I would skip seeing the answer/info.
So this disables the enter key for a few seconds after getting it wrong.